### PR TITLE
Webonix patch flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ This tag created using [PDF Box](http://pdfbox.apache.org/)
 		<cfpdfformparam name="Account" value="MitrahSoft">
 	</cfpdfform>
 
+	<hr>
+	<h4>Populate and remove form fields</h4>
+	<cfpdfform action="populate" source="#pdfForm#" destination="#ExpandPath('./populated-pdf-form.pdf')#" flatten="true">
+		<cfpdfformparam name="Name"    value="CF Mitrah">
+		<cfpdfformparam name="Account" value="MitrahSoft">
+	</cfpdfform>
 
 	<hr>
 	<h4>Populate & write to browser</h4>

--- a/context/library/tag/pdfform.cfc
+++ b/context/library/tag/pdfform.cfc
@@ -11,7 +11,8 @@ component
 		result: { required:false, type:"string",    hint="read - structure containing form field values"},
 		
 		destination: { required:false, type:"string", hint="pathname"},
-		overwrite: { required:false, type:"boolean", hint="overwrite the destination file. default no"}
+		overwrite: { required:false, type:"boolean", hint="overwrite the destination file. default no"},
+		flatten: { required:false, type:"boolean", hint="remove form fields. default no"}
 	};
 
 
@@ -65,6 +66,11 @@ component
 					throw(type="application", message="Destination file exists", detail="#arguments.attributes.destination#");
 				}
 				
+				// flatten: default to false
+				if (! StructKeyExists(arguments.attributes, 'flatten')) {
+					arguments.attributes.flatten = false;
+				}
+				
 				// check for cfpdformparm
 				 break;
 			default: 
@@ -90,7 +96,7 @@ component
 				break;
 			case "populate":
 				if ( isDefined("arguments.attributes.destination")){
-					variables.pdfForm.setFormFields(source = arguments.attributes.source, destination = arguments.attributes.destination, stFormFields = variables.stFormFields);
+					variables.pdfForm.setFormFields(source = arguments.attributes.source, destination = arguments.attributes.destination, stFormFields = variables.stFormFields, flatten=arguments.attributes.flatten);
 				}
 				else {
 					variables.pdfForm.setFormFields(source = arguments.attributes.source, stFormFields = variables.stFormFields);

--- a/context/library/tag/pdfform/pdfform.cfc
+++ b/context/library/tag/pdfform/pdfform.cfc
@@ -38,7 +38,8 @@ component {
             required string source,           
             string destination,         
             required struct stFormFields, 
-            boolean overwrite = true
+            boolean overwrite = true,
+			boolean flatten = false
         )
     {
         var local = {};
@@ -67,6 +68,10 @@ component {
                 fieldName.setValue(ARGUMENTS['stFormFields'][fieldName.getPartialName()]);
             }
         }
+		
+		if (ARGUMENTS.flatten) {
+			local.pdfForm.flatten(); // remove form fields; cannot be edited
+		}
 
         local.pdf.save(local.fileIOS);
         local.pdf.close();


### PR DESCRIPTION
this adds the option to remove the form fields from the newly created PDF so data can no longer be edited.
