### PR TITLE
https://github.com/MitrahSoft/lucee-cfpdfform/issues/9

### DIFF
--- a/source/tags/pdfform/pdfform.cfc
+++ b/source/tags/pdfform/pdfform.cfc
@@ -101,7 +101,7 @@ component {
             local.newPDF = ARGUMENTS.destination;
         }
         else {
-            local.newPDF = expandpath("#getTempDirectory()##createUUID()#.pdf");
+            local.newPDF = expandpath( getTempDirectory() ) & createUUID() & ".pdf";
         }
 
         local.fileIOS   = createObject("java","java.io.FileOutputStream").init(local.newPDF);  


### PR DESCRIPTION
 Improve usage of expandPath() when a destination is not specified